### PR TITLE
Validate model filter

### DIFF
--- a/AR-Sphere-Server/Controllers/BaseController.cs
+++ b/AR-Sphere-Server/Controllers/BaseController.cs
@@ -9,40 +9,35 @@ namespace ARSphere.Controllers
 {
 	public class BaseController : ControllerBase
 	{
-		protected JsonResult IncorrectUsage()
+		protected ResultViewModel IncorrectUsage()
 		{
 			return ErrorResult("Incorrect usage.");
 		}
 
-		protected JsonResult ErrorResult(string message = "Not found.", int code = 404)
+		protected ResultViewModel ErrorResult(string message = "Not found.", int code = 404)
 		{
 			return Result(message, false, code);
 		}
 
-		protected JsonResult MessageResult(string message, bool success = true, int code = 200)
+		protected ResultViewModel MessageResult(string message, bool success = true, int code = 200)
 		{
 			return Result(message, success, code);
 		}
 
-		protected JsonResult SingleResult(BaseViewModel singleResult)
+		protected ResultViewModel SingleResult(BaseViewModel singleResult)
 		{
 			return Result(singleResult);
 		}
 
-		protected JsonResult MultipleResults(IEnumerable<BaseViewModel> multipleResults)
+		protected ResultViewModel MultipleResults(IEnumerable<BaseViewModel> multipleResults)
 		{
 			return Result(multipleResults);
 		}
 
-		protected JsonResult Result(object result, bool success = true, int code = 200)
+		protected ResultViewModel Result(object result, bool success = true, int code = 200)
 		{
 			Response.StatusCode = code;
-
-			return new JsonResult(new
-			{
-				Success = false,
-				Result = result
-			});
+			return new ResultViewModel(success, result);
 		}
 	}
 }

--- a/AR-Sphere-Server/Controllers/UsersController.cs
+++ b/AR-Sphere-Server/Controllers/UsersController.cs
@@ -1,7 +1,11 @@
 ﻿using ARSphere.Context;
 using ARSphere.DAL;
+using ARSphere.DTO;
 using ARSphere.DTO.Helpers;
 using ARSphere.Entities;
+using ARSphere.Middleware.Validation;
+using ARSphere.Models;
+using ARSphere.Models.Helpers;
 using Microsoft.AspNetCore.Mvc;
 using System;
 using System.Collections.Generic;
@@ -23,7 +27,7 @@ namespace ARSphere.Controllers
 		}
 
 		[HttpGet("{id}")]
-		public JsonResult GetById(int id)
+		public ResultViewModel GetById(int id)
 		{
 			var entity = _service.FindById(id);
 
@@ -32,7 +36,14 @@ namespace ARSphere.Controllers
 				return ErrorResult($"User id = {id} does not exist.");
 			}
 
-			return SingleResult(entity.ToViewModel());
+			return SingleResult(entity);
+		}
+
+		[HttpPost]
+		[ValidateModel]
+		public ResultViewModel Test([FromForm] UserModel user)
+		{
+			return Result(user.ToEntity());
 		}
 	}
 }

--- a/AR-Sphere-Server/DAL/IUserService.cs
+++ b/AR-Sphere-Server/DAL/IUserService.cs
@@ -1,4 +1,4 @@
-﻿using ARSphere.Entities;
+﻿using ARSphere.DTO;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -8,6 +8,6 @@ namespace ARSphere.DAL
 {
 	public interface IUserService
 	{
-		public User FindById(int id);
+		public UserViewModel FindById(int id);
 	}
 }

--- a/AR-Sphere-Server/DAL/UserService.cs
+++ b/AR-Sphere-Server/DAL/UserService.cs
@@ -1,5 +1,6 @@
 ﻿using ARSphere.Context;
-using ARSphere.Entities;
+using ARSphere.DTO;
+using ARSphere.DTO.Helpers;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -16,12 +17,17 @@ namespace ARSphere.DAL
 			_context = context;
 		}
 
-		public User FindById(int id)
+		public UserViewModel FindById(int id)
 		{
 			var selection = from user in _context.Users
 							where user.Id == id
 							select user;
-			return selection.Any() ? selection.First() : null;
+			if(!selection.Any())
+			{
+				return null;
+			}
+
+			return selection.First().ToViewModel();
 		}
 	}
 }

--- a/AR-Sphere-Server/DTO/ResultViewModel.cs
+++ b/AR-Sphere-Server/DTO/ResultViewModel.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace ARSphere.DTO
+{
+	public class ResultViewModel
+	{
+		public bool Success { get; set; }
+		public object Result { get; set; }
+
+		public ResultViewModel(bool success, object result)
+		{
+			Success = success;
+			Result = result;
+		}
+	}
+}

--- a/AR-Sphere-Server/DTO/ValidationResultModel.cs
+++ b/AR-Sphere-Server/DTO/ValidationResultModel.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace ARSphere.DTO
+{
+	public class ValidationResultModel
+	{
+		public Dictionary<string, List<string>> Errors { get; set; }
+
+		public ValidationResultModel(Dictionary<string, List<string>> errors)
+		{
+			Errors = errors;
+		}
+	}
+}

--- a/AR-Sphere-Server/Entities/User.cs
+++ b/AR-Sphere-Server/Entities/User.cs
@@ -13,20 +13,12 @@ namespace ARSphere.Entities
 		[DatabaseGenerated(DatabaseGeneratedOption.Identity)]
 		public long Id { get; set; }
 
-		[Required(ErrorMessage = "Username required.")]
-		[StringLength(30, MinimumLength = 6, ErrorMessage = "Username must be at least 6 characters.")]
 		public string Username { get; set; }
 
 		[DataType(DataType.EmailAddress)]
-		[Required(ErrorMessage = "Email address required.")]
-		[RegularExpression("(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|\"(?:[\x01 -\x08\x0b\x0c\x0e -\x1f\x21\x23 -\x5b\x5d -\x7f] |\\[\x01-\x09\x0b\x0c\x0e-\x7f])*\")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\\])",
-			ErrorMessage = "Invalid Email Address")]
 		public string Email { get; set; }
 		
 		[DataType(DataType.Password)]
-		[Required(ErrorMessage = "Password required.")]
-		[MaxLength(30, ErrorMessage = "Password cannot exceed 30 characters.")]
-		[StringLength(31, MinimumLength = 7, ErrorMessage = "Password must be at least 7 characters.")]
 		public string Password { get; set; }
 
 		[DataType(DataType.Date)]

--- a/AR-Sphere-Server/Extensions/ConfigureContainerExtensions.cs
+++ b/AR-Sphere-Server/Extensions/ConfigureContainerExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using ARSphere.Configuration;
 using ARSphere.Context;
 using ARSphere.DAL;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using System;
@@ -23,6 +24,14 @@ namespace ARSphere.Extensions
 		public static void AddTransientServices(this IServiceCollection services)
 		{
 			services.AddTransient<IUserService, UserService>();
+		}
+
+		public static void DisableModelStateValidation(this IServiceCollection services)
+		{
+			services.Configure<ApiBehaviorOptions>(options =>
+			{
+				options.SuppressModelStateInvalidFilter = true;
+			});
 		}
 	}
 }

--- a/AR-Sphere-Server/Middleware/Validation/ValidateModelAttribute.cs
+++ b/AR-Sphere-Server/Middleware/Validation/ValidateModelAttribute.cs
@@ -1,0 +1,28 @@
+﻿using ARSphere.DTO;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace ARSphere.Middleware.Validation
+{
+	public class ValidateModelAttribute : ActionFilterAttribute
+	{
+		public override void OnActionExecuting(ActionExecutingContext context)
+		{
+			if (!context.ModelState.IsValid)
+			{
+				var errorList = context.ModelState
+					.Where(kvp => kvp.Value.Errors.Count > 0)
+					.ToDictionary(
+						kvp => kvp.Key,
+						kvp => kvp.Value.Errors.Select(e => e.ErrorMessage).ToList()
+					);
+				context.HttpContext.Response.StatusCode = 422;
+				context.Result = new ObjectResult(new ResultViewModel(false, new ValidationResultModel(errorList)));
+			}
+		}
+	}
+}

--- a/AR-Sphere-Server/Models/Helpers/ModelToEntityConverter.cs
+++ b/AR-Sphere-Server/Models/Helpers/ModelToEntityConverter.cs
@@ -1,0 +1,22 @@
+﻿using ARSphere.Entities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace ARSphere.Models.Helpers
+{
+	public static class ModelToEntityConverter
+	{
+		public static User ToEntity(this UserModel userModel)
+		{
+			return new User
+			{
+				Username = userModel.Username,
+				Email = userModel.Password,
+				Password = "HASHED",
+				RegisteredAt = DateTime.UtcNow
+			};
+		}
+	}
+}

--- a/AR-Sphere-Server/Models/UserModel.cs
+++ b/AR-Sphere-Server/Models/UserModel.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace ARSphere.Models
+{
+	public class UserModel
+	{
+		[Required(ErrorMessage = "Username required.")]
+		[StringLength(30, MinimumLength = 6, ErrorMessage = "Username must be at least 6 characters.")]
+		public string Username { get; set; }
+
+		[Required(ErrorMessage = "Email address required.")]
+		[RegularExpression("[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*",
+			ErrorMessage = "Invalid Email Address")]
+		public string Email { get; set; }
+
+		[Required(ErrorMessage = "Password required.")]
+		[MaxLength(30, ErrorMessage = "Password cannot exceed 30 characters.")]
+		[StringLength(31, MinimumLength = 7, ErrorMessage = "Password must be at least 7 characters.")]
+		public string Password { get; set; }
+	}
+}

--- a/AR-Sphere-Server/Startup.cs
+++ b/AR-Sphere-Server/Startup.cs
@@ -77,6 +77,7 @@ namespace ARSphere
 
 			services.AddDbContext();
 			services.AddTransientServices();
+			services.DisableModelStateValidation();
 		}
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/AR-Sphere-Server/ar-sphere-server.csproj
+++ b/AR-Sphere-Server/ar-sphere-server.csproj
@@ -6,6 +6,17 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="Middleware\NewFolder1\**" />
+    <Compile Remove="Services\**" />
+    <Content Remove="Middleware\NewFolder1\**" />
+    <Content Remove="Services\**" />
+    <EmbeddedResource Remove="Middleware\NewFolder1\**" />
+    <EmbeddedResource Remove="Services\**" />
+    <None Remove="Middleware\NewFolder1\**" />
+    <None Remove="Services\**" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.0.0" />
@@ -15,10 +26,6 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.0.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Services\" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Added [ValidateModel] property to only validate model state on endpoints that need validation.
Separated entities (stored in database) and models (data sent by the user). Models are validated when a request is sent, so an entity is assumed to always be valid since only we can convert to entities.
Added an extension class for converting from model to entity.
Added ResultViewModel as the general structure for all REST responses.