### PR TITLE
Like Anchor and Client Debugging

### DIFF
--- a/AR-Sphere-Server/DAL/Anchor/AnchorService.cs
+++ b/AR-Sphere-Server/DAL/Anchor/AnchorService.cs
@@ -21,6 +21,14 @@ namespace ARSphere.DAL
     {
         public AnchorService(DatabaseContext _context, IValidationService _validation) : base(_context, _validation) { }
 
+        private Anchor GetEntityById(string id)
+        {
+            var query = from anchor in _context.Anchors
+                        where anchor.Id == id
+                        select anchor;
+            return query.FirstOrDefault();
+        }
+
         public AnchorViewModel GetById(string id)
         {
             var query = from anchor in _context.Anchors
@@ -107,6 +115,15 @@ namespace ARSphere.DAL
                             .DefaultIfEmpty()
                         select anchor.ToViewModel(user, model, promotion, sponsor);
             return query.ToList();
+        }
+
+        public AnchorLikedViewModel LikeAnchor(string anchorId, int userId)
+        {
+            Anchor anchor = GetEntityById(anchorId);
+            anchor.LikedBy.Add(userId);
+            _context.Anchors.Update(anchor);
+            _context.SaveChangesAsync();
+            return anchor.ToLikedViewModel();
         }
     }
 }

--- a/AR-Sphere-Server/DAL/Anchor/IAnchorService.cs
+++ b/AR-Sphere-Server/DAL/Anchor/IAnchorService.cs
@@ -14,6 +14,7 @@ namespace ARSphere.DAL
         public Task CreateAnchor(NewAnchorModel model, int creatorId);
         public Task<AnchorViewModel> CreateAnchorAndGet(NewAnchorModel anchor, int creatorId);
         public AnchorViewModel GetLast();
-        public IEnumerable<AnchorViewModel> GetAnchorsInRadius(Point location, double radius = 100);
+        public IEnumerable<AnchorViewModel> GetAnchorsInRadius(Point location, double radius);
+        public AnchorLikedViewModel LikeAnchor(string anchorId, int userId);
 	}
 }

--- a/AR-Sphere-Server/DTO/AnchorViewModel.cs
+++ b/AR-Sphere-Server/DTO/AnchorViewModel.cs
@@ -1,7 +1,9 @@
-﻿using NetTopologySuite.Geometries;
+﻿using ARSphere.DTO.Converters;
+using NetTopologySuite.Geometries;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 
 namespace ARSphere.DTO
@@ -13,7 +15,10 @@ namespace ARSphere.DTO
     {
         public string Id { get; set; }
         public ARModelViewModel Model { get; set; }
+
+        [JsonConverter(typeof(PointConverter))]
         public Point Location { get; set; }
+        
         public UserViewModelPublic CreatedBy { get; set; }
         public DateTime CreatedAt { get; set; }
         // TODO: Change to LikeCount and LikedByUser
@@ -27,7 +32,10 @@ namespace ARSphere.DTO
     public class AnchorLikedViewModel : BaseViewModel
     {
         public string Id { get; set; }
+
+        [JsonConverter(typeof(PointConverter))]
         public Point Location { get; set; }
+
         public List<int> LikedBy { get; set; }
     }
 }

--- a/AR-Sphere-Server/DTO/AnchorViewModel.cs
+++ b/AR-Sphere-Server/DTO/AnchorViewModel.cs
@@ -16,6 +16,18 @@ namespace ARSphere.DTO
         public Point Location { get; set; }
         public UserViewModelPublic CreatedBy { get; set; }
         public DateTime CreatedAt { get; set; }
+        // TODO: Change to LikeCount and LikedByUser
+        // LikedByUser would be retrieved by the current user's Authentication, since their ID is linked to it with each request
+        public List<int> LikedBy { get; set; }
+    }
+
+    /// <summary>
+    /// <para>Public data format to say a model's like field has been updated.</para>
+    /// </summary>
+    public class AnchorLikedViewModel : BaseViewModel
+    {
+        public string Id { get; set; }
+        public Point Location { get; set; }
         public List<int> LikedBy { get; set; }
     }
 }

--- a/AR-Sphere-Server/DTO/Converters/PointConverter.cs
+++ b/AR-Sphere-Server/DTO/Converters/PointConverter.cs
@@ -17,7 +17,7 @@ namespace ARSphere.DTO.Converters
         public override Point Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             JsonElement parsed = JsonSerializer.Deserialize<JsonElement>(ref reader, options);
-            return new Point(parsed.GetProperty("x").GetDouble(), parsed.GetProperty("y").GetDouble()) 
+            return new Point(parsed.GetProperty("X").GetDouble(), parsed.GetProperty("Y").GetDouble()) 
             {
                 SRID = 4326
             };
@@ -25,7 +25,10 @@ namespace ARSphere.DTO.Converters
 
         public override void Write(Utf8JsonWriter writer, Point value, JsonSerializerOptions options)
         {
-            throw new NotImplementedException();
+            writer.WriteStartObject();
+            writer.WriteNumber("X", value.X);
+            writer.WriteNumber("Y", value.Y);
+            writer.WriteEndObject();
         }
     }
 }

--- a/AR-Sphere-Server/DTO/Helpers/EntityToViewModelConverter.cs
+++ b/AR-Sphere-Server/DTO/Helpers/EntityToViewModelConverter.cs
@@ -118,7 +118,7 @@ namespace ARSphere.DTO.Helpers
         /// </summary>
         /// <param name="user"></param>
         /// <returns></returns>
-        public static UserViewModelPrivate ToViewModelPrivate (this User user)
+        public static UserViewModelPrivate ToViewModelPrivate(this User user)
         {
             return new UserViewModelPrivate
             {
@@ -128,6 +128,21 @@ namespace ARSphere.DTO.Helpers
                 ProfileImageUrl = user.ProfileImageUrl,
                 Currency = user.Currency,
                 Level = user.Level
+            };
+        }
+
+        /// <summary>
+        /// <para>Converts an Anchor entity to the view model for updated like field.</para>
+        /// </summary>
+        /// <param name="anchor"></param>
+        /// <returns></returns>
+        public static AnchorLikedViewModel ToLikedViewModel(this Anchor anchor)
+        {
+            return new AnchorLikedViewModel
+            {
+                Id = anchor.Id,
+                Location = anchor.Location,
+                LikedBy = anchor.LikedBy
             };
         }
     }

--- a/AR-Sphere-Server/Extensions/ConfigurePipelineExtensions.cs
+++ b/AR-Sphere-Server/Extensions/ConfigurePipelineExtensions.cs
@@ -2,6 +2,7 @@
 using ARSphere.Middleware.ExceptionHandling;
 using ARSphere.Persistent;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http.Connections;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using System;
@@ -25,7 +26,10 @@ namespace ARSphere.Extensions
             app.UseRouting();
             app.UseEndpoints(endpoints =>
             {
-                endpoints.MapHub<MasterHub>("/connect");
+                endpoints.MapHub<MasterHub>("/connect", options =>
+                {
+                    options.Transports = HttpTransportType.WebSockets;
+                });
                 endpoints.MapControllers();
             });
         }

--- a/AR-Sphere-Server/Hubs/Client.cs
+++ b/AR-Sphere-Server/Hubs/Client.cs
@@ -13,6 +13,7 @@ namespace ARSphere.Hubs
     public interface IClient
     {
         Task NewNearbyAnchor(AnchorViewModel anchor);
+        Task UpdateAnchorLikes(AnchorLikedViewModel anchor);
     }
 
     /// <summary>
@@ -22,6 +23,11 @@ namespace ARSphere.Hubs
     {
         public Point Location { get; set; }
         public int UserId { get; set; }
+
+        public Client()
+        {
+            Location = new Point(double.NaN, double.NaN) { SRID = 4326 };
+        }
 
         public void SetLocation(double longitude, double latitude)
         {

--- a/AR-Sphere-Server/Models/Helpers/ModelToEntityConverter.cs
+++ b/AR-Sphere-Server/Models/Helpers/ModelToEntityConverter.cs
@@ -28,6 +28,12 @@ namespace ARSphere.Models.Helpers
             };
         }
 
+        /// <summary>
+        /// <para>Converts model data for an Anchor into an entity for the database.</para>
+        /// </summary>
+        /// <param name="anchorModel"></param>
+        /// <param name="creatorId"></param>
+        /// <returns></returns>
         public static Anchor ToEntity(this NewAnchorModel anchorModel, int creatorId)
         {
             return new Anchor

--- a/AR-Sphere-Server/Persistent/Helpers/SeedData/AnchorSeedData.json
+++ b/AR-Sphere-Server/Persistent/Helpers/SeedData/AnchorSeedData.json
@@ -3,8 +3,8 @@
         "Id": "seed-anchor-1",
         "Model": 0,
         "Location": {
-            "x": 58.99949,
-            "y": 16.99949
+            "X": 58.99949,
+            "Y": 16.99949
         },
         "CreatedBy": 1,
         "CreatedAt": "2019-10-27T02:37:00",
@@ -14,8 +14,8 @@
         "Id": "seed-anchor-2",
         "Model": 0,
         "Location": {
-            "x": 59.00149,
-            "y": 17.00149
+            "X": 59.00149,
+            "Y": 17.00149
         },
         "CreatedBy": 1,
         "CreatedAt": "2019-10-27T08:59:00",
@@ -25,8 +25,8 @@
         "Id": "seed-anchor-3",
         "Model": 0,
         "Location": {
-            "x": 59,
-            "y": 17
+            "X": 59,
+            "Y": 17
         },
         "CreatedBy": 1,
         "CreatedAt": "2019-10-27T09:00:00",
@@ -36,8 +36,8 @@
         "Id": "seed-anchor-4",
         "Model": 0,
         "Location": {
-            "x": 59.00149,
-            "y": 17
+            "X": 59.00149,
+            "Y": 17
         },
         "CreatedBy": 1,
         "CreatedAt": "2019-10-27T09:01:00",

--- a/ClientTest/ClientTest.cs
+++ b/ClientTest/ClientTest.cs
@@ -11,7 +11,7 @@ namespace ClientTest
 {
     class ClientTest
     {
-        private HubConnection connection;
+        private readonly HubConnection connection;
         private readonly string Url = "https://localhost:44336/connect";
         // private readonly string Url = "https://ar-sphere-server.azurewebsites.net/connect";
         private bool Connected = false;
@@ -22,12 +22,13 @@ namespace ClientTest
                 .WithUrl(Url)
                 .Build();
 
-            connection.ServerTimeout = TimeSpan.FromSeconds(10);
-
             connection.Closed += async (error) =>
             {
                 Console.WriteLine("Connection closed.");
-                await connection.StartAsync();
+                if(Connected)
+                {
+                    await connection.StartAsync();
+                }
             };
         }
 

--- a/ClientTest/ClientTest.cs
+++ b/ClientTest/ClientTest.cs
@@ -12,8 +12,8 @@ namespace ClientTest
     class ClientTest
     {
         private HubConnection connection;
-        private string Url = "https://localhost:44336/connect";
-        // private string Url = "https://ar-sphere-server.azurewebsites.net/connect";
+        private readonly string Url = "https://localhost:44336/connect";
+        // private readonly string Url = "https://ar-sphere-server.azurewebsites.net/connect";
         private bool Connected = false;
 
         public ClientTest()
@@ -21,6 +21,8 @@ namespace ClientTest
             connection = new HubConnectionBuilder()
                 .WithUrl(Url)
                 .Build();
+
+            connection.ServerTimeout = TimeSpan.FromSeconds(10);
 
             connection.Closed += async (error) =>
             {
@@ -78,6 +80,7 @@ namespace ClientTest
                 Console.WriteLine("Response: " + res);
 
                 AnchorViewModel lastAnchor = await connection.InvokeAsync<AnchorViewModel>("GetLastAnchor");
+                Console.WriteLine(lastAnchor.Id);
 
                 IEnumerable<AnchorViewModel> nearbyAnchors = await connection.InvokeAsync<IEnumerable<AnchorViewModel>>("GetNearbyAnchors", 59, 17);
                 Console.WriteLine(string.Join(", ", nearbyAnchors.Select(m => m.Id)));


### PR DESCRIPTION
Added ability to like anchors alongside receiving updates for nearby anchors that have been liked.
A few refactored areas of the overall hub design.
Spent major time debugging sending anchors from the database to the client. It turns out that my custom JsonConverter is needed to also write the Point class to the output of SignalR. After finding this problem, the solution was painless.